### PR TITLE
feat: generate starting bag from weighted pip-sum 5-7 pool

### DIFF
--- a/server/src/routes/runs.ts
+++ b/server/src/routes/runs.ts
@@ -82,9 +82,7 @@ router.post('/start', async (req: Request, res: Response) => {
   const firstNode = map.find((n) => n.row === 0) ?? map[0];
   const currentNodeId = firstNode?.id ?? null;
 
-  const defaultBag = new Bag();
-  defaultBag.shuffle();
-  const initialStones = [...defaultBag.stones];
+  const initialStones = new Bag().generateStartingBag(14);
 
   const runState = {
     run,

--- a/src/game/__tests__/bag.test.ts
+++ b/src/game/__tests__/bag.test.ts
@@ -1,5 +1,5 @@
 import { Bag } from '../bag';
-import { Stone } from '../models/stone';
+import { Stone, ElementType } from '../models/stone';
 
 function makeStone(left: number, right: number): Stone {
   return { id: `stone-${left}-${right}`, leftPip: left, rightPip: right, element: null };
@@ -103,6 +103,71 @@ describe('Bag', () => {
       const stone = makeStone(2, 5);
       bag.addStone(stone);
       expect(bag.stones).toContain(stone);
+    });
+  });
+
+  describe('generateStartingBag', () => {
+    it('returns exactly count stones', () => {
+      const bag = new Bag();
+      const stones = bag.generateStartingBag(14);
+      expect(stones.length).toBe(14);
+    });
+
+    it('all stones have pip sum of 5, 6, or 7', () => {
+      const bag = new Bag();
+      const stones = bag.generateStartingBag(14);
+      for (const stone of stones) {
+        const sum = stone.leftPip + stone.rightPip;
+        expect([5, 6, 7]).toContain(sum);
+      }
+    });
+
+    it('exactly one stone has a non-null element', () => {
+      const bag = new Bag();
+      const stones = bag.generateStartingBag(14);
+      const elemental = stones.filter((s) => s.element !== null);
+      expect(elemental.length).toBe(1);
+    });
+
+    it('the elemental stone has a valid element type', () => {
+      const bag = new Bag();
+      const stones = bag.generateStartingBag(14);
+      const elemental = stones.find((s) => s.element !== null)!;
+      expect(Object.values(ElementType)).toContain(elemental.element);
+    });
+
+    it('all stones have unique IDs', () => {
+      const bag = new Bag();
+      const stones = bag.generateStartingBag(14);
+      const ids = stones.map((s) => s.id);
+      expect(new Set(ids).size).toBe(14);
+    });
+
+    it('distribution is approximately 25% sum-5, 50% sum-6, 25% sum-7 over many runs', () => {
+      const bag = new Bag();
+      let count5 = 0, count6 = 0, count7 = 0;
+      const iterations = 1000;
+      const stonesPerRun = 14;
+      for (let i = 0; i < iterations; i++) {
+        for (const stone of bag.generateStartingBag(stonesPerRun)) {
+          const sum = stone.leftPip + stone.rightPip;
+          if (sum === 5) count5++;
+          else if (sum === 6) count6++;
+          else if (sum === 7) count7++;
+        }
+      }
+      const total = iterations * stonesPerRun;
+      expect(count5 / total).toBeCloseTo(0.25, 1); // ±0.05 tolerance
+      expect(count6 / total).toBeCloseTo(0.50, 1);
+      expect(count7 / total).toBeCloseTo(0.25, 1);
+    });
+
+    it('produces different subsets across runs (random)', () => {
+      const bag = new Bag();
+      const run1 = bag.generateStartingBag(14).map((s) => `${s.leftPip}-${s.rightPip}`).join(',');
+      const run2 = bag.generateStartingBag(14).map((s) => `${s.leftPip}-${s.rightPip}`).join(',');
+      // Very unlikely to be identical across two random 14-stone draws
+      expect(run1).not.toBe(run2);
     });
   });
 

--- a/src/game/bag.ts
+++ b/src/game/bag.ts
@@ -1,4 +1,12 @@
-import { Stone } from './models/stone';
+import { Stone, ElementType } from './models/stone';
+
+const STARTING_POOLS: Array<[number, number][]> = [
+  [[0, 5], [1, 4], [2, 3]],          // sum 5 — 25%
+  [[0, 6], [1, 5], [2, 4], [3, 3]],  // sum 6 — 50%
+  [[1, 6], [2, 5], [3, 4]],          // sum 7 — 25%
+];
+const STARTING_WEIGHTS = [0.25, 0.50, 0.25];
+const ALL_ELEMENTS = Object.values(ElementType) as ElementType[];
 
 export class Bag {
   public stones: Stone[];
@@ -19,6 +27,26 @@ export class Bag {
         });
       }
     }
+    return stones;
+  }
+
+  generateStartingBag(count: number): Stone[] {
+    const stones: Stone[] = [];
+    for (let i = 0; i < count; i++) {
+      const roll = Math.random();
+      let groupIndex = 0;
+      let cumulative = 0;
+      for (let g = 0; g < STARTING_WEIGHTS.length; g++) {
+        cumulative += STARTING_WEIGHTS[g];
+        if (roll < cumulative) { groupIndex = g; break; }
+      }
+      const pool = STARTING_POOLS[groupIndex];
+      const [left, right] = pool[Math.floor(Math.random() * pool.length)];
+      stones.push({ id: crypto.randomUUID(), leftPip: left, rightPip: right, element: null });
+    }
+    const elementalIndex = Math.floor(Math.random() * count);
+    const element = ALL_ELEMENTS[Math.floor(Math.random() * ALL_ELEMENTS.length)];
+    stones[elementalIndex] = { ...stones[elementalIndex], element };
     return stones;
   }
 


### PR DESCRIPTION
Player bag now initialized with 14 curated stones (pip sum 5-7, weighted 25/50/25) instead of random draw from full 28-stone set. One stone gets a random element. Adds generateStartingBag(count) method to Bag class.